### PR TITLE
feat: add KCL deployment module with Gateway API HTTPRoute support

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,202 @@
+# machinery-registry-api Kubernetes Deployment
+
+KCL module for deploying machinery-registry-api on Kubernetes.
+
+## Render Manifests
+
+```bash
+# Default configuration (outputs YAML)
+kcl run main.k -D config.registryRepo="stuttgart-things/harvester"
+
+# Output as JSON
+kcl run main.k -D config.registryRepo="stuttgart-things/harvester" --format json
+```
+
+## Override Variables
+
+Use `-D` flag to override configuration at render time:
+
+```bash
+# Override namespace and replicas
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.namespace=production \
+  -D config.replicas=3
+
+# Override image
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.image="ghcr.io/stuttgart-things/machinery-registry-api:v1.0.0"
+
+# Custom registry config
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.registryPath="claims/registry.yaml" \
+  -D config.registryBranch="main" \
+  -D config.syncInterval="30s"
+
+# Enable ingress with custom host
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.ingressEnabled=True \
+  -D config.ingressHost="registry-api.example.com"
+
+# Enable Gateway API HTTPRoute (alternative to ingress)
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.httpRouteEnabled=True \
+  -D config.httpRouteParentRefName="main-gateway" \
+  -D config.httpRouteHostname="registry-api.example.com"
+
+# HTTPRoute with gateway in different namespace
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.httpRouteEnabled=True \
+  -D config.httpRouteParentRefName="main-gateway" \
+  -D config.httpRouteParentRefNamespace="gateway-system" \
+  -D config.httpRouteHostname="registry-api.example.com"
+```
+
+## Apply to Cluster
+
+```bash
+# Render and apply directly (pipe through yq to split manifests array)
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.namespace=machinery-registry \
+  | yq '.manifests | (.[] | splitDoc)' - \
+  | kubectl apply -f -
+
+# Dry-run (server-side validation)
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  | yq '.manifests | (.[] | splitDoc)' - \
+  | kubectl apply --dry-run=server -f -
+
+# Delete resources
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  | yq '.manifests | (.[] | splitDoc)' - \
+  | kubectl delete -f -
+```
+
+## Available Variables
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `config.name` | string | `machinery-registry-api` | Application name |
+| `config.namespace` | string | `default` | Kubernetes namespace |
+| `config.image` | string | `ghcr.io/stuttgart-things/machinery-registry-api:latest` | Container image |
+| `config.imagePullPolicy` | string | `IfNotPresent` | Image pull policy |
+| `config.replicas` | int | `1` | Number of replicas |
+| `config.cpuRequest` | string | `100m` | CPU request |
+| `config.cpuLimit` | string | `500m` | CPU limit |
+| `config.memoryRequest` | string | `128Mi` | Memory request |
+| `config.memoryLimit` | string | `256Mi` | Memory limit |
+| `config.serviceType` | string | `ClusterIP` | Service type |
+| `config.servicePort` | int | `8090` | Service port |
+| `config.containerPort` | int | `8090` | Container port |
+| `config.ingressEnabled` | bool | `False` | Enable ingress |
+| `config.ingressClassName` | string | `nginx` | Ingress class |
+| `config.ingressHost` | string | `machinery-registry-api.example.com` | Ingress hostname |
+| `config.ingressTlsEnabled` | bool | `False` | Enable TLS |
+| `config.ingressTlsSecretName` | string | `machinery-registry-api-tls` | TLS secret name |
+| `config.ingressAnnotations` | {str:str} | `{}` | Ingress annotations |
+| `config.httpRouteEnabled` | bool | `False` | Enable Gateway API HTTPRoute |
+| `config.httpRouteParentRefName` | string | `` | Gateway name (required when httpRouteEnabled) |
+| `config.httpRouteParentRefNamespace` | string | `` | Gateway namespace (optional) |
+| `config.httpRouteHostname` | string | `` | HTTPRoute hostname (defaults to ingressHost) |
+| `config.httpRouteAnnotations` | {str:str} | `{}` | HTTPRoute annotations |
+| `config.registryRepo` | string | `` | GitHub repo slug (required, e.g. `stuttgart-things/harvester`) |
+| `config.registryPath` | string | `claims/registry.yaml` | Path to registry file in the repo |
+| `config.registryBranch` | string | `main` | Git branch to fetch from |
+| `config.syncInterval` | string | `60s` | Polling interval for GitHub sync |
+| `config.port` | string | `8090` | Application port (PORT env var) |
+| `config.logFormat` | string | `text` | Log format (`text` or `json`) |
+| `config.extraEnvVars` | {str:str} | `{}` | Extra environment variables for ConfigMap |
+| `config.secrets` | {str:str} | `{}` | Secret key-value pairs, e.g. `{"GITHUB_TOKEN": "ghp_..."}` |
+| `config.serviceAccountAnnotations` | {str:str} | `{}` | ServiceAccount annotations |
+| `config.labels` | {str:str} | `{}` | Additional labels for resources |
+| `config.annotations` | {str:str} | `{}` | Additional annotations for resources |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `schema.k` | Configuration schema |
+| `labels.k` | Common labels |
+| `serviceaccount.k` | ServiceAccount resource |
+| `configmap.k` | ConfigMap resource |
+| `secret.k` | Secret resource |
+| `deploy.k` | Deployment resource |
+| `service.k` | Service resource |
+| `ingress.k` | Ingress resource |
+| `httproute.k` | HTTPRoute resource (Gateway API) |
+| `main.k` | Entry point |
+
+## Gateway API Example
+
+The deployment supports [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute as an alternative to Ingress. This requires a Gateway resource deployed on the cluster (e.g. with Cilium).
+
+### Example Gateway (Cilium)
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: whatever-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.whatever.sthings-vsphere.labul.sva.de"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-whatever-tls
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.whatever.sthings-vsphere.labul.sva.de"
+      allowedRoutes:
+        namespaces:
+          from: All
+```
+
+> **Note:** Set `allowedRoutes.namespaces.from: All` on the Gateway listeners to allow HTTPRoutes from other namespaces. With `from: Same` (default), only routes in the Gateway's own namespace are accepted.
+
+### Deploy with HTTPRoute
+
+```bash
+# Render and apply with Gateway API HTTPRoute
+kcl run main.k \
+  -D config.registryRepo="stuttgart-things/harvester" \
+  -D config.namespace=machinery-registry \
+  -D config.httpRouteEnabled=True \
+  -D config.httpRouteParentRefName="whatever-gateway" \
+  -D config.httpRouteParentRefNamespace="default" \
+  -D config.httpRouteHostname="registry-api.whatever.sthings-vsphere.labul.sva.de" \
+  | yq '.manifests | (.[] | splitDoc)' - \
+  | kubectl apply -f -
+```
+
+### Verify HTTPRoute
+
+```bash
+# Check HTTPRoute status (should show Accepted: True)
+kubectl -n machinery-registry get httproute machinery-registry-api
+
+# Check HTTPRoute details
+kubectl -n machinery-registry get httproute machinery-registry-api -o yaml | yq '.status.parents[0].conditions'
+
+# Test endpoint
+curl http://registry-api.whatever.sthings-vsphere.labul.sva.de/health
+curl http://registry-api.whatever.sthings-vsphere.labul.sva.de/api/v1/claims
+```

--- a/deployment/configmap.k
+++ b/deployment/configmap.k
@@ -1,0 +1,27 @@
+"""
+ConfigMap for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+configMap = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        REGISTRY_REPO: config.registryRepo
+        REGISTRY_PATH: config.registryPath
+        REGISTRY_BRANCH: config.registryBranch
+        SYNC_INTERVAL: config.syncInterval
+        PORT: config.port
+        LOG_FORMAT: config.logFormat
+        **config.extraEnvVars
+    }
+}

--- a/deployment/deploy.k
+++ b/deployment/deploy.k
@@ -1,0 +1,122 @@
+"""
+Deployment for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+deployment = {
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations:
+            annotations: config.annotations
+    }
+    spec: {
+        replicas: config.replicas
+        selector: {
+            matchLabels: labels.selectorLabels
+        }
+        template: {
+            metadata: {
+                labels: labels.commonLabels
+                if config.annotations:
+                    annotations: config.annotations
+            }
+            spec: {
+                serviceAccountName: config.name
+                containers: [
+                    {
+                        name: config.name
+                        image: config.image
+                        imagePullPolicy: config.imagePullPolicy
+                        ports: [
+                            {
+                                name: "http"
+                                containerPort: config.containerPort
+                                protocol: "TCP"
+                            }
+                        ]
+                        envFrom: [
+                            {
+                                configMapRef: {
+                                    name: config.name
+                                }
+                            }
+                        ] + ([
+                            {
+                                secretRef: {
+                                    name: config.name
+                                }
+                            }
+                        ] if config.secrets else [])
+                        resources: {
+                            requests: {
+                                cpu: config.cpuRequest
+                                memory: config.memoryRequest
+                            }
+                            limits: {
+                                cpu: config.cpuLimit
+                                memory: config.memoryLimit
+                            }
+                        }
+                        livenessProbe: {
+                            httpGet: {
+                                path: "/health"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 10
+                            periodSeconds: 15
+                            timeoutSeconds: 5
+                            failureThreshold: 3
+                        }
+                        readinessProbe: {
+                            httpGet: {
+                                path: "/health"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 5
+                            periodSeconds: 10
+                            timeoutSeconds: 3
+                            failureThreshold: 3
+                        }
+                        securityContext: {
+                            readOnlyRootFilesystem: True
+                            runAsNonRoot: True
+                            allowPrivilegeEscalation: False
+                            capabilities: {
+                                drop: ["ALL"]
+                            }
+                        }
+                        volumeMounts: [
+                            {
+                                name: "tmp"
+                                mountPath: "/tmp"
+                            }
+                        ]
+                    }
+                ]
+                securityContext: {
+                    runAsNonRoot: True
+                    runAsUser: 65532
+                    runAsGroup: 65532
+                    fsGroup: 65532
+                    seccompProfile: {
+                        type: "RuntimeDefault"
+                    }
+                }
+                volumes: [
+                    {
+                        name: "tmp"
+                        emptyDir: {}
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/deployment/httproute.k
+++ b/deployment/httproute.k
@@ -1,0 +1,54 @@
+"""
+HTTPRoute (Gateway API) for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+_hostname = config.httpRouteHostname or config.ingressHost
+
+httproute = {
+    apiVersion: "gateway.networking.k8s.io/v1"
+    kind: "HTTPRoute"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations or config.httpRouteAnnotations:
+            annotations: {
+                **config.annotations
+                **config.httpRouteAnnotations
+            }
+    }
+    spec: {
+        parentRefs: [
+            {
+                name: config.httpRouteParentRefName
+                if config.httpRouteParentRefNamespace:
+                    namespace: config.httpRouteParentRefNamespace
+            }
+        ]
+        if _hostname:
+            hostnames: [_hostname]
+        rules: [
+            {
+                matches: [
+                    {
+                        path: {
+                            type: "PathPrefix"
+                            value: "/"
+                        }
+                    }
+                ]
+                backendRefs: [
+                    {
+                        name: config.name
+                        port: config.servicePort
+                    }
+                ]
+            }
+        ]
+    }
+} if config.httpRouteEnabled else None

--- a/deployment/ingress.k
+++ b/deployment/ingress.k
@@ -1,0 +1,54 @@
+"""
+Ingress for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+ingress = {
+    apiVersion: "networking.k8s.io/v1"
+    kind: "Ingress"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        annotations: {
+            "nginx.ingress.kubernetes.io/ssl-redirect": "true" if config.ingressTlsEnabled else "false"
+            **config.annotations
+            **config.ingressAnnotations
+        }
+    }
+    spec: {
+        ingressClassName: config.ingressClassName
+        if config.ingressTlsEnabled:
+            tls: [
+                {
+                    hosts: [config.ingressHost]
+                    secretName: config.ingressTlsSecretName
+                }
+            ]
+        rules: [
+            {
+                host: config.ingressHost
+                http: {
+                    paths: [
+                        {
+                            path: "/"
+                            pathType: "Prefix"
+                            backend: {
+                                service: {
+                                    name: config.name
+                                    port: {
+                                        number: config.servicePort
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+} if config.ingressEnabled else None

--- a/deployment/kcl.mod
+++ b/deployment/kcl.mod
@@ -1,0 +1,12 @@
+[package]
+name = "deploy-machinery-registry-api"
+version = "0.1.0"
+description = "KCL module for deploying machinery-registry-api on Kubernetes"
+
+[dependencies]
+k8s = "1.31"
+
+[profile]
+entries = [
+    "main.k"
+]

--- a/deployment/kcl.mod.lock
+++ b/deployment/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.k8s]
+    name = "k8s"
+    full_name = "k8s_1.31"
+    version = "1.31"
+    sum = "LqN5u8Jvj1/2ozrLL0PafXTmtqj7HfxYCHwnEf0WmkQ="
+    reg = "ghcr.io"
+    repo = "kcl-lang/k8s"
+    oci_tag = "1.31"

--- a/deployment/labels.k
+++ b/deployment/labels.k
@@ -1,0 +1,74 @@
+"""
+Common labels for machinery-registry-api resources
+"""
+
+import schema
+
+# Get command-line options
+_image = option("config.image")
+_namespace = option("config.namespace")
+_ingressEnabled = option("config.ingressEnabled")
+_ingressHost = option("config.ingressHost")
+_ingressTlsEnabled = option("config.ingressTlsEnabled")
+_ingressAnnotations = option("config.ingressAnnotations") or {}
+_httpRouteEnabled = option("config.httpRouteEnabled")
+_httpRouteParentRefName = option("config.httpRouteParentRefName")
+_httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
+_httpRouteHostname = option("config.httpRouteHostname")
+_httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_registryRepo = option("config.registryRepo")
+_registryPath = option("config.registryPath")
+_registryBranch = option("config.registryBranch")
+_syncInterval = option("config.syncInterval")
+_extraEnvVars = option("config.extraEnvVars") or {}
+
+# Config instance with command-line overrides
+config: schema.MachineryRegistryAPI = schema.MachineryRegistryAPI {
+    if _image:
+        image = _image
+    if _namespace:
+        namespace = _namespace
+    if _ingressEnabled:
+        ingressEnabled = _ingressEnabled in [True, "True", "true"]
+    if _ingressHost:
+        ingressHost = _ingressHost
+    if _ingressTlsEnabled:
+        ingressTlsEnabled = _ingressTlsEnabled in [True, "True", "true"]
+    if _ingressAnnotations:
+        ingressAnnotations = _ingressAnnotations
+    if _httpRouteEnabled:
+        httpRouteEnabled = _httpRouteEnabled in [True, "True", "true"]
+    if _httpRouteParentRefName:
+        httpRouteParentRefName = _httpRouteParentRefName
+    if _httpRouteParentRefNamespace:
+        httpRouteParentRefNamespace = _httpRouteParentRefNamespace
+    if _httpRouteHostname:
+        httpRouteHostname = _httpRouteHostname
+    if _httpRouteAnnotations:
+        httpRouteAnnotations = _httpRouteAnnotations
+    if _registryRepo:
+        registryRepo = _registryRepo
+    if _registryPath:
+        registryPath = _registryPath
+    if _registryBranch:
+        registryBranch = _registryBranch
+    if _syncInterval:
+        syncInterval = _syncInterval
+    if _extraEnvVars:
+        extraEnvVars = _extraEnvVars
+}
+
+# Common labels applied to all resources
+commonLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+    "app.kubernetes.io/component": "api"
+    "app.kubernetes.io/part-of": "machinery-registry"
+    **config.labels
+}
+
+# Selector labels for pods
+selectorLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+}

--- a/deployment/main.k
+++ b/deployment/main.k
@@ -1,0 +1,27 @@
+"""
+Main entry point for machinery-registry-api Kubernetes deployment
+Imports all resources and exports manifests
+"""
+
+import namespace
+import serviceaccount
+import configmap
+import secret
+import deploy
+import service
+import ingress
+import httproute
+
+# Export all manifests (filter out None values)
+manifests = [
+    m for m in [
+        namespace.namespace
+        serviceaccount.serviceAccount
+        configmap.configMap
+        secret.secret
+        deploy.deployment
+        service.service
+        ingress.ingress
+        httproute.httproute
+    ] if m
+]

--- a/deployment/namespace.k
+++ b/deployment/namespace.k
@@ -1,0 +1,17 @@
+"""
+Namespace for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+namespace = {
+    apiVersion: "v1"
+    kind: "Namespace"
+    metadata: {
+        name: config.namespace
+        labels: labels.commonLabels
+    }
+}

--- a/deployment/schema.k
+++ b/deployment/schema.k
@@ -1,0 +1,70 @@
+"""
+Schema definition for machinery-registry-api deployment configuration
+"""
+
+schema MachineryRegistryAPI:
+    """Configuration for machinery-registry-api Kubernetes deployment"""
+
+    # Metadata
+    name: str = "machinery-registry-api"
+    namespace: str = "default"
+
+    # Image
+    image: str = "ghcr.io/stuttgart-things/machinery-registry-api:latest"
+    imagePullPolicy: str = "IfNotPresent"
+
+    # Replicas and resources
+    replicas: int = 1
+    cpuRequest: str = "100m"
+    cpuLimit: str = "500m"
+    memoryRequest: str = "128Mi"
+    memoryLimit: str = "256Mi"
+
+    # Service
+    serviceType: str = "ClusterIP"
+    servicePort: int = 8090
+    containerPort: int = 8090
+
+    # Ingress
+    ingressEnabled: bool = False
+    ingressClassName: str = "nginx"
+    ingressHost: str = "machinery-registry-api.example.com"
+    ingressTlsEnabled: bool = False
+    ingressTlsSecretName: str = "machinery-registry-api-tls"
+    ingressAnnotations: {str:str} = {}
+
+    # HTTPRoute (Gateway API)
+    httpRouteEnabled: bool = False
+    httpRouteParentRefName: str = ""
+    httpRouteParentRefNamespace: str = ""
+    httpRouteHostname: str = ""
+    httpRouteAnnotations: {str:str} = {}
+
+    # Registry config (required)
+    registryRepo: str = ""  # GitHub repo slug (e.g. stuttgart-things/harvester)
+    registryPath: str = "claims/registry.yaml"
+    registryBranch: str = "main"
+    syncInterval: str = "60s"
+
+    # Application config
+    port: str = "8090"
+    logFormat: str = "text"
+
+    # Extra environment variables
+    extraEnvVars: {str:str} = {}
+
+    # Secrets (will be base64 encoded)
+    secrets: {str:str} = {}  # e.g. {"GITHUB_TOKEN": "ghp_..."}
+
+    # ServiceAccount
+    serviceAccountAnnotations: {str:str} = {}
+
+    # Labels and annotations
+    labels: {str:str} = {}
+    annotations: {str:str} = {}
+
+    check:
+        replicas >= 0, "replicas must be >= 0"
+        servicePort >= 1 and servicePort <= 65535, "servicePort must be valid"
+        containerPort >= 1 and containerPort <= 65535, "containerPort must be valid"
+        len(registryRepo) > 0, "registryRepo must be set (e.g. stuttgart-things/harvester)"

--- a/deployment/secret.k
+++ b/deployment/secret.k
@@ -1,0 +1,24 @@
+"""
+Secret for machinery-registry-api
+"""
+
+import base64
+import schema
+import labels
+
+config = labels.config
+
+secret = {
+    apiVersion: "v1"
+    kind: "Secret"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    type: "Opaque"
+    data: {
+        k: base64.encode(v)
+        for k, v in config.secrets
+    }
+} if config.secrets else None

--- a/deployment/service.k
+++ b/deployment/service.k
@@ -1,0 +1,30 @@
+"""
+Service for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+service = {
+    apiVersion: "v1"
+    kind: "Service"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        type: config.serviceType
+        ports: [
+            {
+                name: "http"
+                port: config.servicePort
+                targetPort: "http"
+                protocol: "TCP"
+            }
+        ]
+        selector: labels.selectorLabels
+    }
+}

--- a/deployment/serviceaccount.k
+++ b/deployment/serviceaccount.k
@@ -1,0 +1,20 @@
+"""
+ServiceAccount for machinery-registry-api
+"""
+
+import schema
+import labels
+
+config = labels.config
+
+serviceAccount = {
+    apiVersion: "v1"
+    kind: "ServiceAccount"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.serviceAccountAnnotations:
+            annotations: config.serviceAccountAnnotations
+    }
+}


### PR DESCRIPTION
## Summary
- Add KCL-based Kubernetes deployment module (14 files in `deployment/`)
- Support both Ingress and Gateway API HTTPRoute for traffic routing
- Schema includes registry-specific config (`REGISTRY_REPO`, `SYNC_INTERVAL`, `GITHUB_TOKEN` secret)
- Docs with real-world Cilium Gateway example and verification commands

## Test plan
- [x] KCL renders valid manifests with `kcl run main.k -D config.registryRepo=stuttgart-things/harvester`
- [x] Deployed to vre2 cluster with HTTPRoute to `whatever-gateway` (Cilium)
- [x] Health check passing at `registry-api.whatever.sthings-vsphere.labul.sva.de/health`
- [ ] Verify CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)